### PR TITLE
Add missing ordering relationship between file{ $dirs: and Exec['post-install']

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,8 @@ class influxdbrelay (
 
   file { $dirs:
     ensure => 'directory',
-    mode   => '0755'
+    mode   => '0755',
+    before => Exec['post-install'],
   }
 
   file { '/etc/environment':


### PR DESCRIPTION
Hi!

This pull request fixes non-determinism in the manifests.

Specifically, it adds a missing ordering relationship between the creation of the `/var/lib/influxdb-relay`, `/var/log/influxdb-relay` directories and the `post-install` command.

Below, it is what I get when the Puppet processes resources in the following erroneous order:

```
Notice: /Stage[main]/Influxdbrelay/File[/var/lib/influxdb-relay]/ensure: created
Notice: /Stage[main]/Influxdbrelay/Exec[post-install]/returns: executed successfully
Notice: /Stage[main]/Influxdbrelay/File[/var/log/influxdb-relay]/ensure: created
```

It is easy to see that the ownership of the `/var/log/influxdb-relay` is not set properly.
The desired owner of the files is set by the post-install script and is `influxdb-relay`. But now the the owner of the `/var/log/influxdb-relay` is `root`.

To fix this issue, the creation of the directories must always precede the execution of the script.